### PR TITLE
#18 generate matchers for query parameters

### DIFF
--- a/src/main/groovy/org/springframework/cloud/contract/verifier/converter/OpenApiContractConverter.groovy
+++ b/src/main/groovy/org/springframework/cloud/contract/verifier/converter/OpenApiContractConverter.groovy
@@ -97,7 +97,7 @@ class OpenApiContractConverter implements ContractConverter<Collection<PathItem>
                             def contractPath = (StringUtils.isEmpty(openApiContract.contractPath)) ? path : openApiContract.contractPath
 
                             yamlContract.request = new YamlContract.Request()
-                            yamlContract.request.url = contractPath
+                            yamlContract.request.urlPath = contractPath
 
                             if (pathItem?.get?.is(operation)) {
                                 yamlContract.request.method = "GET"
@@ -177,6 +177,12 @@ class OpenApiContractConverter implements ContractConverter<Collection<PathItem>
                                         if (contractBody?.cookies) {
                                             contractBody?.cookies?.each { cookieVal ->
                                                 yamlContract.request.cookies.put(cookieVal.key, cookieVal.value)
+                                            }
+                                        }
+
+                                        if (contractBody?.queryParameters) {
+                                            contractBody?.queryParameters.each { k, v ->
+                                                yamlContract.request.queryParameters.put(k, v)
                                             }
                                         }
 
@@ -392,7 +398,7 @@ class OpenApiContractConverter implements ContractConverter<Collection<PathItem>
                             ignored.name = "Ignored Contract"
                             ignored.ignored = true
                             ignored.request = new YamlContract.Request()
-                            ignored.request.url = "/ignored"
+                            ignored.request.urlPath = "/ignored"
                             ignored.request.method = "GET"
                             ignored.response = new YamlContract.Response()
                           //  sccContracts.add(ignored)

--- a/src/test/groovy/org/springframework/cloud/contract/verifier/converter/OpenApiContactConverterTest.groovy
+++ b/src/test/groovy/org/springframework/cloud/contract/verifier/converter/OpenApiContactConverterTest.groovy
@@ -99,6 +99,7 @@ class OpenApiContactConverterTest extends Specification {
         then:
         openApiContract
         yamlContract.request.url == openApiContract.request.url
+        yamlContract.request.urlPath == openApiContract.request.urlPath
         yamlContract.request.method == openApiContract.request.method
         yamlContract.request.cookies == openApiContract.request.cookies
         yamlContract.request.headers == openApiContract.request.headers
@@ -134,7 +135,7 @@ class OpenApiContactConverterTest extends Specification {
 
         then:
         contract
-        contract.getRequest().url.clientValue.equals("/foo1")
+        contract.getRequest().urlPath.clientValue.equals("/foo1")
     }
 
     def "Test Parse of Payor example contracts"() {
@@ -176,7 +177,10 @@ class OpenApiContactConverterTest extends Specification {
         then:
         //contract
         contactConverter.isAccepted(matcherFileOA3)
-       // yamlContract.request.url == openApiContract.request.url
+        yamlContract.request.url == openApiContract.request.url
+        yamlContract.request.urlPath.queryParameters == openApiContract.request.urlPath.queryParameters
+        yamlContract.request.urlPath.serverValue.toString() == openApiContract.request.urlPath.serverValue.toString()
+        yamlContract.request.urlPath.clientValue.toString() == openApiContract.request.urlPath.clientValue.toString()
         yamlContract.request.method == openApiContract.request.method
         yamlContract.request.cookies == openApiContract.request.cookies
         yamlContract.request.headers == openApiContract.request.headers
@@ -186,7 +190,6 @@ class OpenApiContactConverterTest extends Specification {
         yamlContract.response.headers == openApiContract.response.headers
         yamlContract.response.bodyMatchers == openApiContract.response.bodyMatchers
         yamlContract.response.body == openApiContract.response.body // has empty list, which does not convert
-
     }
 
 }

--- a/src/test/resources/openapi/contract_matchers.yml
+++ b/src/test/resources/openapi/contract_matchers.yml
@@ -5,6 +5,39 @@ info:
 paths:
     /get/1:
         get:
+            parameters:
+                - in: query
+                  name: limit
+                  schema:
+                      type: integer
+                - in: query
+                  name: offset
+                  schema:
+                      type: integer
+                - in: query
+                  name: filter
+                  schema:
+                      type: string
+                - in: query
+                  name: sort
+                  schema:
+                      type: string
+                - in: query
+                  name: search
+                  schema:
+                      type: integer
+                - in: query
+                  name: age
+                  schema:
+                      type: integer
+                - in: query
+                  name: name
+                  schema:
+                      type: string
+                - in: query
+                  name: email
+                  schema:
+                      type: string
             x-contracts:
                 -   contractId: 1
                     name: Contract Matchers Test

--- a/src/test/resources/yml/contract.yml
+++ b/src/test/resources/yml/contract.yml
@@ -15,7 +15,7 @@ request:
 #end::request[]
 #tag::request_obligatory[]
   method: PUT
-  url: /foo
+  urlPath: /foo
 #end::request_obligatory[]
 #tag::query_params[]
   queryParameters:


### PR DESCRIPTION
This fixes #18. 

Please note that I also had to change the generation of the property `url` to `urlPath` as that's the recommended way to make it host-independent ([reference](https://cloud.spring.io/spring-cloud-contract/2.0.x/multi/multi__contract_dsl.html#_request)).